### PR TITLE
ページについてFBの修正

### DIFF
--- a/components/electricity_app.html
+++ b/components/electricity_app.html
@@ -61,8 +61,8 @@
 
             <div class="electricity-summary">
                 <h4>年間サマリー</h4>
-                <p>年間電力使用量: <span id="total-kwh">0</span> kWh</p>
                 <p>年間CO2排出量: <span id="total-co2-kg">0</span> g</p>
+                <p>年間電力使用量: <span id="total-kwh">0</span> kWh</p>
             </div>
 
             <button id="save-electricity-data-btn" class="save-btn">データを保存</button>
@@ -70,11 +70,11 @@
 
         <!-- 右側：グラフ表示エリア -->
         <div class="electricity-chart-section">
-            <h3>電力使用量グラフ</h3>
-            <canvas id="electricity-chart"></canvas>
-
-            <h3 style="margin-top: 30px; color: #f44336;">CO2排出量グラフ</h3>
+            <h3 style="color: #f44336;">CO2排出量グラフ</h3>
             <canvas id="co2-chart"></canvas>
+
+            <h3 style="margin-top: 30px;">電力使用量グラフ</h3>
+            <canvas id="electricity-chart"></canvas>
         </div>
     </div>
 </div>

--- a/components/top_screen.html
+++ b/components/top_screen.html
@@ -5,14 +5,12 @@
     <!-- 温室効果ガスサマリー -->
     <div class="greenhouse-summary">
         <div class="summary-total">
-            <div class="summary-icon">🌍</div>
             <div class="summary-content">
                 <div class="summary-label">全体の排出量</div>
                 <div class="summary-value-large"><span id="total-co2">0</span> g CO2</div>
             </div>
         </div>
         <div class="summary-reduction">
-            <div class="summary-icon">✅</div>
             <div class="summary-content">
                 <div class="summary-label">削減できた量</div>
                 <div class="summary-value-large"><span id="total-reduction">0</span> g CO2</div>

--- a/components/top_screen.html
+++ b/components/top_screen.html
@@ -20,6 +20,11 @@
         </div>
     </div>
 
+    <!-- カテゴリー選択の説明 -->
+    <div class="category-description">
+        <p>記録したい項目を選択してください</p>
+    </div>
+
     <div class="top-buttons">
         <button id="btn-school">通学</button>
         <button id="btn-gas">ガス</button>

--- a/components/top_screen.html
+++ b/components/top_screen.html
@@ -11,6 +11,13 @@
                 <div class="summary-value-large"><span id="total-co2">0</span> g CO2</div>
             </div>
         </div>
+        <div class="summary-reduction">
+            <div class="summary-icon">✅</div>
+            <div class="summary-content">
+                <div class="summary-label">削減できた量</div>
+                <div class="summary-value-large"><span id="total-reduction">0</span> g CO2</div>
+            </div>
+        </div>
     </div>
 
     <div class="top-buttons">

--- a/script.js
+++ b/script.js
@@ -314,9 +314,17 @@ document.addEventListener('DOMContentLoaded', () => {
         // 全体のCO2排出量（g単位）
         const totalCo2 = electricityCo2 + plasticBagCo2;
 
+        // 削減できた量の計算（g単位）
+        const CO2_SAVED_PER_REFUSAL = 1.2;
+        const refusalCount = parseInt(localStorage.getItem('refusalCount') || '0', 10);
+        const totalReduction = refusalCount * CO2_SAVED_PER_REFUSAL;
+
         // HTMLに表示（g単位）
         const totalCo2El = document.getElementById('total-co2');
         if (totalCo2El) totalCo2El.textContent = totalCo2.toFixed(1);
+
+        const totalReductionEl = document.getElementById('total-reduction');
+        if (totalReductionEl) totalReductionEl.textContent = totalReduction.toFixed(1);
     }
 
     // --- Initial App Load ---

--- a/style.css
+++ b/style.css
@@ -44,6 +44,22 @@ body {
   margin: 20px 0;
 }
 
+/* カテゴリー選択の説明 */
+.category-description {
+  width: 100%;
+  max-width: 400px;
+  margin: 20px 0 10px;
+  text-align: center;
+}
+
+.category-description p {
+  color: white;
+  font-size: 1rem;
+  font-weight: 500;
+  margin: 0;
+  text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
+}
+
 .top-buttons {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/style.css
+++ b/style.css
@@ -75,9 +75,12 @@ body {
   width: 100%;
   max-width: 400px;
   margin: 15px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
 }
 
-.summary-total {
+.summary-total, .summary-reduction {
   display: flex;
   align-items: center;
   gap: 15px;
@@ -89,7 +92,7 @@ body {
   transition: transform 0.2s;
 }
 
-.summary-total:hover {
+.summary-total:hover, .summary-reduction:hover {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
 }
@@ -115,6 +118,10 @@ body {
   font-size: 2rem;
   font-weight: bold;
   color: #2e7d32;
+}
+
+.summary-reduction .summary-value-large {
+  color: #1976d2; /* 削減量は青色で表示 */
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
#6 
# 概要
HPのレイアウトなどについてコメントをいただいたため、修正を行う。修正ないうようについては以下に記載する。

> 温室効果ガスの排出量がありますが、ユーザーの行動変容によって削減できた量もわかるとよいと思います。

topページに「削除できた量」の要素を追加した。計算方法に関しては、レジ袋の断った回数から計算を行っている。

> その下の項目毎のボタンですが、はじめて見た人は、唐突感があって、なんのボタンなのかわからないかもしれないですね。

項目の状況部分に、「記録したい項目を選択してください」と追記し、唐突感が内容に修正を行った。
もっと良い解決方法があったら、教えて欲しいです。

> 電力のところは、kWh を下にして、CO2の排出量を上した方がよいかと。kWhは、エネルギー事業社のサイトでも見られるので。

電力ページについて修正を行った。

